### PR TITLE
ツール一覧の検索バグを修正

### DIFF
--- a/pages/tools/index.tsx
+++ b/pages/tools/index.tsx
@@ -18,11 +18,15 @@ type Props = {
 
 // 実際に使用されているツールのみを抽出する
 const getAllToolsDataInUse = () => {
-  const toolsNameInServices = getToolsNameInPostsData()
+  const toolsNameInServices = getToolsNameInPostsData().map((name) =>
+    name.toLowerCase(),
+  )
   const allToolsData = getAllToolsData().filter((toolData) => {
     return (
-      toolsNameInServices.includes(toolData.toolName) ||
-      toolData.alias?.some((name) => toolsNameInServices.includes(name))
+      toolsNameInServices.includes(toolData.toolName.toLowerCase()) ||
+      toolData.alias?.some((name) =>
+        toolsNameInServices.includes(name.toLowerCase()),
+      )
     )
   })
   return allToolsData


### PR DESCRIPTION
# 概要

ツール一覧画面でサービスで使用中でツール名で検索しても、検索にヒットしない不具合を修正した。

# 詳細

サービスで使用中のツール名とMarkdownで管理しているマスターのツール名とエイリアスを完全一致で
検索していたため、小文字に変換した上で文字列比較をするようにした。