### PR TITLE
OpenAPIをAPI関連ツールのカテゴリに移動

### DIFF
--- a/posts/duet_code.md
+++ b/posts/duet_code.md
@@ -44,6 +44,7 @@ stack:
         version: 
       - name: Flyio
         version:
+
   - name: テスト
     detail:
       - name: committee-rails
@@ -66,6 +67,9 @@ stack:
         version: 
       - name: Lefthook
         version:
+
+  - name: API関連ツール
+    detail:
       - name: OpenAPI
         version: 3.0.3
       - name: OpenAPI Generator


### PR DESCRIPTION
# 概要

Duet CodeのOpenAPIのツールを環境構築のカテゴリから
API関連ツールのカテゴリに移動した。