### PR TITLE
Fix key prop typos

### DIFF
--- a/components/ServiceContent.tsx
+++ b/components/ServiceContent.tsx
@@ -75,7 +75,7 @@ const ServiceContent: NextPage<Props> = ({ postData }) => {
       <Box py={5}>
         <Box id="stack">
           {postData.stack.map(({ name, detail }) => (
-            <Box key="{name}" p={5} mb={5} border="1px solid #eee">
+            <Box key={name} p={5} mb={5} border="1px solid #eee">
               <Box>
                 <b>
                   {name} ({detail.length})
@@ -95,7 +95,7 @@ const ServiceContent: NextPage<Props> = ({ postData }) => {
                         href={`/tools/${postData.toolPathInfo![name]}`}
                         passHref
                         legacyBehavior
-                        key="{name}"
+                        key={name}
                       >
                         <ToolButton
                           name={name}

--- a/components/ToolButton.tsx
+++ b/components/ToolButton.tsx
@@ -18,7 +18,6 @@ const ToolButton = React.forwardRef<
       style={{ textDecoration: 'none' }}
     >
       <Box
-        key="{id}"
         style={{
           borderRadius: '8px',
           minHeight: '120px',

--- a/pages/tools/index.tsx
+++ b/pages/tools/index.tsx
@@ -86,13 +86,13 @@ const Tools: NextPage<Props> = ({ allToolsData }) => {
           gap={{ base: 3, md: 6 }}
         >
           {filteredItems.map(({ toolID, toolName }) => (
-            <GridItem w="100%" key={toolID}>
-              <Link
-                href={`/tools/${toolID}`}
-                passHref
-                legacyBehavior
-                key="{toolID}"
-              >
+              <GridItem w="100%" key={toolID}>
+                <Link
+                  href={`/tools/${toolID}`}
+                  passHref
+                  legacyBehavior
+                  key={toolID}
+                >
                 <ToolButton name={toolName} id={toolID} version="" />
               </Link>
             </GridItem>

--- a/pages/tools/index.tsx
+++ b/pages/tools/index.tsx
@@ -91,7 +91,6 @@ const Tools: NextPage<Props> = ({ allToolsData }) => {
                   href={`/tools/${toolID}`}
                   passHref
                   legacyBehavior
-                  key={toolID}
                 >
                 <ToolButton name={toolName} id={toolID} version="" />
               </Link>


### PR DESCRIPTION
## Summary
- correct `key` prop usage in ServiceContent, ToolButton, and tools listing

## Testing
- `npm ci`
- `npx next lint`


------
https://chatgpt.com/codex/tasks/task_e_6840828666dc8323a7c09b14c1015eba