### PR TITLE
画像のalt属性を適切な値に修正

### DIFF
--- a/app/components/ServiceCard.tsx
+++ b/app/components/ServiceCard.tsx
@@ -21,7 +21,7 @@ function ToolIcon({ toolID, name }: { toolID: string; name: string }) {
         src={`/images/tool/${toolID}.png`}
         width={14}
         height={14}
-        alt=""
+        alt={name}
         className="h-3.5 w-3.5 object-contain"
         onError={() => setShow(false)}
       />
@@ -73,7 +73,7 @@ export default function ServiceCard({ post }: Props) {
               height={24}
               placeholder="blur"
               blurDataURL={getBlurDataURL()}
-              alt=""
+              alt={`${author}のアバター`}
               className="h-6 w-6 object-cover"
             />
           </div>

--- a/app/components/ToolSearch.tsx
+++ b/app/components/ToolSearch.tsx
@@ -35,7 +35,7 @@ function ToolItem({
         <div className="relative h-8 w-8 shrink-0">
           <Image
             src={imgSrc}
-            alt=""
+            alt={toolName}
             placeholder="blur"
             blurDataURL={getBlurDataURL()}
             fill

--- a/app/posts/[id]/page.tsx
+++ b/app/posts/[id]/page.tsx
@@ -67,7 +67,7 @@ export default function PostPage({ params }: { params: { id: string } }) {
               src={`https://github.com/${postData.author}.png`}
               width={36}
               height={36}
-              alt=""
+              alt={`${postData.author}のアバター`}
               placeholder="blur"
               blurDataURL={getBlurDataURL()}
               className="h-9 w-9 object-cover"
@@ -95,6 +95,7 @@ export default function PostPage({ params }: { params: { id: string } }) {
                     width={16}
                     height={16}
                     alt=""
+                    aria-hidden="true"
                     className="h-4 w-4"
                   />
                   GitHub
@@ -109,6 +110,7 @@ export default function PostPage({ params }: { params: { id: string } }) {
                     width={16}
                     height={16}
                     alt=""
+                    aria-hidden="true"
                     className="h-4 w-4"
                   />
                   DeepWiki

--- a/app/tools/[id]/ToolImage.tsx
+++ b/app/tools/[id]/ToolImage.tsx
@@ -4,14 +4,14 @@ import { useState } from 'react'
 import Image from 'next/image'
 import { getBlurDataURL } from '../../lib/image'
 
-export default function ToolImage({ toolID }: { toolID: string }) {
+export default function ToolImage({ toolID, toolName }: { toolID: string; toolName?: string }) {
   const [imageSrc, setImageSrc] = useState(`/images/tool/${toolID}.png`)
 
   return (
     <div className="relative h-14 w-14">
       <Image
         src={imageSrc}
-        alt="logo"
+        alt={toolName ?? toolID}
         fill
         placeholder="blur"
         blurDataURL={getBlurDataURL()}

--- a/app/tools/[id]/page.tsx
+++ b/app/tools/[id]/page.tsx
@@ -59,7 +59,7 @@ export default function ToolDetailPage({
       <div className="rounded-xl bg-gradient-to-br from-gray-50 to-gray-100 p-6 md:p-8">
         <div className="flex items-center gap-4">
           <div className="shrink-0">
-            <ToolImage toolID={toolData.toolID} />
+            <ToolImage toolID={toolData.toolID} toolName={toolData.toolName} />
           </div>
           <div className="min-w-0">
             <h1 className="text-xl font-bold md:text-2xl">


### PR DESCRIPTION
## Summary
- ツールアイコンにツール名を alt として設定
- アバター画像に `{author}のアバター` を alt として設定
- 装飾的なリンクアイコン（GitHub, DeepWiki, Blog, Website）に `aria-hidden="true"` を追加
- `ToolImage` コンポーネントに `toolName` prop を追加し、固定値 `"logo"` の代わりにツール名を表示

## 変更ファイル
- `app/components/ServiceCard.tsx`
- `app/components/ToolSearch.tsx`
- `app/posts/[id]/page.tsx`
- `app/tools/[id]/ToolImage.tsx`
- `app/tools/[id]/page.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)