### PR TITLE
類似サービス・併用ツール・採用トレンドの表示を追加

### DIFF
--- a/app/components/ToolListItem.tsx
+++ b/app/components/ToolListItem.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { getBlurDataURL } from '../lib/image'
+
+type Props = {
+  toolID: string
+  toolName: string
+  badge?: string
+}
+
+export default function ToolListItem({ toolID, toolName, badge }: Props) {
+  const [imgSrc, setImgSrc] = useState(`/images/tool/${toolID}.png`)
+
+  return (
+    <Link href={`/tools/${toolID}`} className="block">
+      <div className="flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-gray-100">
+        <div className="relative h-8 w-8 shrink-0">
+          <Image
+            src={imgSrc}
+            alt={toolName}
+            placeholder="blur"
+            blurDataURL={getBlurDataURL()}
+            fill
+            onError={() => setImgSrc('/images/noimage.png')}
+            className="object-contain"
+          />
+        </div>
+        <span className="min-w-0 flex-1 truncate text-sm font-medium text-gray-700">
+          {toolName}
+        </span>
+        {badge && (
+          <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500">
+            {badge}
+          </span>
+        )}
+      </div>
+    </Link>
+  )
+}

--- a/app/components/ToolSearch.tsx
+++ b/app/components/ToolSearch.tsx
@@ -1,9 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import Image from 'next/image'
-import Link from 'next/link'
-import { getBlurDataURL } from '../lib/image'
+import ToolListItem from './ToolListItem'
 import type { ToolData } from '../../types/toolData'
 
 type ToolWithStats = ToolData & { usageCount: number }
@@ -16,42 +14,6 @@ type GroupedTools = {
 type Props = {
   allToolsData: ToolWithStats[]
   grouped: GroupedTools[]
-}
-
-function ToolItem({
-  toolID,
-  toolName,
-  usageCount,
-}: {
-  toolID: string
-  toolName: string
-  usageCount: number
-}) {
-  const [imgSrc, setImgSrc] = useState(`/images/tool/${toolID}.png`)
-
-  return (
-    <Link href={`/tools/${toolID}`} className="block">
-      <div className="flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-gray-100">
-        <div className="relative h-8 w-8 shrink-0">
-          <Image
-            src={imgSrc}
-            alt={toolName}
-            placeholder="blur"
-            blurDataURL={getBlurDataURL()}
-            fill
-            onError={() => setImgSrc('/images/noimage.png')}
-            className="object-contain"
-          />
-        </div>
-        <span className="min-w-0 flex-1 truncate text-sm font-medium text-gray-700">
-          {toolName}
-        </span>
-        <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500">
-          {usageCount}
-        </span>
-      </div>
-    </Link>
-  )
 }
 
 export default function ToolSearch({ allToolsData, grouped }: Props) {
@@ -97,11 +59,11 @@ export default function ToolSearch({ allToolsData, grouped }: Props) {
           </div>
           <div className="grid grid-cols-1 gap-0.5 sm:grid-cols-2">
             {filteredItems.map(({ toolID, toolName, usageCount }) => (
-              <ToolItem
+              <ToolListItem
                 key={toolID}
                 toolID={toolID}
                 toolName={toolName}
-                usageCount={usageCount}
+                badge={String(usageCount)}
               />
             ))}
           </div>
@@ -132,11 +94,11 @@ export default function ToolSearch({ allToolsData, grouped }: Props) {
                 </div>
                 <div className="grid grid-cols-1 gap-0.5 p-2 sm:grid-cols-2 md:grid-cols-3">
                   {tools.map(({ toolID, toolName, usageCount }) => (
-                    <ToolItem
+                    <ToolListItem
                       key={toolID}
                       toolID={toolID}
                       toolName={toolName}
-                      usageCount={usageCount}
+                      badge={String(usageCount)}
                     />
                   ))}
                 </div>

--- a/app/lib/related.ts
+++ b/app/lib/related.ts
@@ -1,0 +1,113 @@
+import { getSortedPostsData, getFilteredPostsData } from './posts'
+import { getAllToolsData } from './tools'
+import type { PostData } from '../../types/postData'
+import type { ToolData } from '../../types/toolData'
+
+function getToolIDSet(post: PostData): Set<string> {
+  return new Set(Object.values(post.toolPathInfo ?? {}))
+}
+
+// 技術スタックのJaccard類似度が高い順に他のサービスを返す
+export function getRelatedPosts(currentId: string, limit = 4): PostData[] {
+  const posts = getSortedPostsData()
+  const current = posts.find(({ id }) => id === currentId)
+  if (!current) return []
+
+  const currentTools = getToolIDSet(current)
+  if (currentTools.size === 0) return []
+
+  const scored = posts
+    .filter(({ id }) => id !== currentId)
+    .map((post) => {
+      const tools = getToolIDSet(post)
+      let shared = 0
+      tools.forEach((toolID) => {
+        if (currentTools.has(toolID)) shared++
+      })
+      const unionSize = currentTools.size + tools.size - shared
+      return {
+        post,
+        shared,
+        similarity: unionSize > 0 ? shared / unionSize : 0,
+      }
+    })
+    // 共通ツール1件だけの偶然の一致は除外
+    .filter(({ shared }) => shared >= 2)
+
+  return scored
+    .sort(
+      (a, b) =>
+        b.similarity - a.similarity ||
+        b.shared - a.shared ||
+        b.post.date.localeCompare(a.post.date),
+    )
+    .slice(0, limit)
+    .map(({ post }) => post)
+}
+
+export type CoUsedTool = {
+  toolID: string
+  toolName: string
+  count: number
+  rate: number
+}
+
+// 対象ツールを採用しているサービスで、一緒に使われているツールを集計する
+export function getCoUsedTools(toolData: ToolData, limit = 12): CoUsedTool[] {
+  const posts = getFilteredPostsData(toolData)
+  if (posts.length === 0) return []
+
+  const countMap = new Map<string, number>()
+  for (const post of posts) {
+    getToolIDSet(post).forEach((toolID) => {
+      if (toolID === toolData.toolID) return
+      countMap.set(toolID, (countMap.get(toolID) || 0) + 1)
+    })
+  }
+
+  const allTools = getAllToolsData()
+  return Array.from(countMap.entries())
+    .map(([toolID, count]) => ({
+      toolID,
+      toolName: allTools.find((t) => t.toolID === toolID)?.toolName ?? toolID,
+      count,
+      rate: Math.round((count / posts.length) * 100),
+    }))
+    .sort((a, b) => b.count - a.count || a.toolName.localeCompare(b.toolName))
+    .slice(0, limit)
+}
+
+export type YearlyAdoption = {
+  year: string
+  count: number
+  total: number
+  rate: number
+}
+
+// 対象ツールの年ごとの採用サービス数と採用率を返す
+export function getToolYearlyAdoption(toolData: ToolData): YearlyAdoption[] {
+  const totalByYear = new Map<string, number>()
+  for (const post of getSortedPostsData()) {
+    const year = post.date.slice(0, 4)
+    totalByYear.set(year, (totalByYear.get(year) || 0) + 1)
+  }
+
+  const countByYear = new Map<string, number>()
+  for (const post of getFilteredPostsData(toolData)) {
+    const year = post.date.slice(0, 4)
+    countByYear.set(year, (countByYear.get(year) || 0) + 1)
+  }
+
+  return Array.from(totalByYear.keys())
+    .sort()
+    .map((year) => {
+      const total = totalByYear.get(year) || 0
+      const count = countByYear.get(year) || 0
+      return {
+        year,
+        count,
+        total,
+        rate: total > 0 ? Math.round((count / total) * 100) : 0,
+      }
+    })
+}

--- a/app/lib/tools.ts
+++ b/app/lib/tools.ts
@@ -5,12 +5,27 @@ import type { ToolData } from '../../types/toolData'
 
 const toolsDirectory = path.join(process.cwd(), 'tools')
 
+// Cache parsed tools to avoid repeated file I/O during build
+let cachedAllTools: ToolData[] | null = null
+
 export function getAllToolsData(): ToolData[] {
+  if (cachedAllTools) return cachedAllTools
+
   const fileNames = fs.readdirSync(toolsDirectory)
-  return fileNames.map((fileName) => {
+  cachedAllTools = fileNames.map((fileName) => {
     const id = fileName.replace(/\.md$/, '')
     return getToolData(id)
   })
+  return cachedAllTools
+}
+
+export function findToolByName(name: string): ToolData | undefined {
+  const lower = name.toLowerCase()
+  return getAllToolsData().find(
+    (t) =>
+      t.toolName.toLowerCase() === lower ||
+      t.alias?.some((a) => a.toLowerCase() === lower),
+  )
 }
 
 export function getToolData(id: string): ToolData {

--- a/app/posts/[id]/page.tsx
+++ b/app/posts/[id]/page.tsx
@@ -3,12 +3,14 @@ import Link from 'next/link'
 import type { Metadata } from 'next'
 import { getAllPostIds, getPostData } from '../../lib/posts'
 import { getPodcastData } from '../../lib/podcast'
+import { getRelatedPosts } from '../../lib/related'
 import { getBlurDataURL } from '../../lib/image'
 import DateDisplay from '../../components/DateDisplay'
 import ExternalLink from '../../components/ExternalLink'
 import ServiceContent from '../../components/ServiceContent'
 import AudioPlayer from '../../components/AudioPlayer'
 import Breadcrumb from '../../components/Breadcrumb'
+import ServiceCard from '../../components/ServiceCard'
 
 export function generateStaticParams() {
   return getAllPostIds()
@@ -44,6 +46,7 @@ export function generateMetadata({
 export default function PostPage({ params }: { params: { id: string } }) {
   const postData = getPostData(params.id)
   const podcastData = postData.hasAudio ? getPodcastData(params.id) : null
+  const relatedPosts = getRelatedPosts(params.id)
 
   const totalTools = postData.stack.reduce(
     (sum, cat) => sum + cat.detail.length,
@@ -168,6 +171,23 @@ export default function PostPage({ params }: { params: { id: string } }) {
       <div className="mt-5">
         <ServiceContent postData={postData} />
       </div>
+
+      {/* Related services */}
+      {relatedPosts.length > 0 && (
+        <section className="mt-10">
+          <h2 className="mb-1 text-lg font-bold">
+            似た技術スタックのサービス
+          </h2>
+          <p className="mb-3 text-sm text-light-text">
+            使用ツールの構成が近いサービスです。実装の参考にどうぞ
+          </p>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-5">
+            {relatedPosts.map((post) => (
+              <ServiceCard key={post.id} post={post} />
+            ))}
+          </div>
+        </section>
+      )}
 
       <div className="mt-10">
         <Link

--- a/app/tools/[id]/page.tsx
+++ b/app/tools/[id]/page.tsx
@@ -2,7 +2,9 @@ import Link from 'next/link'
 import type { Metadata } from 'next'
 import { getAllToolsData, getToolData } from '../../lib/tools'
 import { getFilteredPostsData } from '../../lib/posts'
+import { getCoUsedTools, getToolYearlyAdoption } from '../../lib/related'
 import ServiceCard from '../../components/ServiceCard'
+import ToolListItem from '../../components/ToolListItem'
 import ToolImage from './ToolImage'
 import Breadcrumb from '../../components/Breadcrumb'
 
@@ -45,6 +47,9 @@ export default function ToolDetailPage({
 }) {
   const toolData = getToolData(params.id)
   const allPostsData = getFilteredPostsData(toolData)
+  const coUsedTools = getCoUsedTools(toolData)
+  const yearlyAdoption = getToolYearlyAdoption(toolData)
+  const hasAdoption = yearlyAdoption.some(({ count }) => count > 0)
 
   return (
     <>
@@ -94,6 +99,76 @@ export default function ToolDetailPage({
           </div>
         </div>
       </div>
+
+      {/* Yearly adoption trend */}
+      {hasAdoption && (
+        <section className="mt-5">
+          <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+            <div className="border-b border-gray-100 bg-gray-50 px-5 py-3">
+              <h2 className="text-sm font-semibold text-gray-700">
+                年別採用トレンド
+              </h2>
+              <p className="mt-0.5 text-xs text-gray-400">
+                各年に登録されたサービスのうち、このツールを採用した割合
+              </p>
+            </div>
+            <div className="p-5">
+              <div className="space-y-2">
+                {yearlyAdoption.map(({ year, count, total, rate }) => (
+                  <div key={year} className="flex items-center gap-3">
+                    <span className="w-12 shrink-0 text-right text-xs text-gray-500">
+                      {year}
+                    </span>
+                    <div className="flex flex-1 items-center gap-2">
+                      <div className="h-5 flex-1 rounded-full bg-gray-100">
+                        <div
+                          className="h-5 rounded-full bg-blue-500 transition-all"
+                          style={{
+                            width: `${rate}%`,
+                            minWidth: count > 0 ? '4px' : '0',
+                          }}
+                        />
+                      </div>
+                      <span className="w-24 shrink-0 text-right text-xs text-gray-600">
+                        <span className="font-semibold">{count}</span>
+                        <span className="text-gray-400"> / {total}件</span>
+                        <span className="ml-1 font-semibold">{rate}%</span>
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Frequently co-used tools */}
+      {coUsedTools.length > 0 && (
+        <section className="mt-5">
+          <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+            <div className="border-b border-gray-100 bg-gray-50 px-5 py-3">
+              <h2 className="text-sm font-semibold text-gray-700">
+                一緒によく使われるツール
+              </h2>
+              <p className="mt-0.5 text-xs text-gray-400">
+                {toolData.toolName}
+                を採用しているサービスで併用されているツール（併用率）
+              </p>
+            </div>
+            <div className="grid grid-cols-1 gap-0.5 p-2 sm:grid-cols-2 md:grid-cols-3">
+              {coUsedTools.map(({ toolID, toolName, rate }) => (
+                <ToolListItem
+                  key={toolID}
+                  toolID={toolID}
+                  toolName={toolName}
+                  badge={`${rate}%`}
+                />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* Services using this tool */}
       <div className="mt-5">

--- a/tools/rspec.md
+++ b/tools/rspec.md
@@ -1,6 +1,6 @@
 ---
-toolName: rspec
+toolName: RSpec
 alias:
-  - RSpec
+  - rspec
 url: https://rspec.info/
 ---

--- a/tools/rubocop.md
+++ b/tools/rubocop.md
@@ -1,7 +1,7 @@
 ---
-toolName: rubocop
+toolName: RuboCop
 alias:
-  - RuboCop
+  - rubocop
   - Rubocop
 url: https://github.com/rubocop/rubocop
 ---

--- a/tools/ruby.md
+++ b/tools/ruby.md
@@ -1,6 +1,6 @@
 ---
-toolName: ruby
+toolName: Ruby
 alias:
-  - Ruby
+  - ruby
 url: https://www.ruby-lang.org/ja/
 ---


### PR DESCRIPTION
## 概要

受講生が「参考サービス探し」と「自作サービスの技術選定」をしやすくなるよう、回遊導線と技術選定の判断材料を追加しました。すべてビルド時の静的生成のみで完結し、新規依存はありません。

## 変更内容

### 1. サービス詳細ページ：「似た技術スタックのサービス」
- 使用ツール構成のJaccard類似度が高いサービスを最大4件表示
- 共通ツールが1件だけの偶然の一致はノイズとして除外

### 2. ツール詳細ページ：「一緒によく使われるツール」
- そのツールを採用しているサービス内での併用率を集計して表示
- 例: Ruby on Rails → RuboCop 93%・GitHub Actions 83%・RSpec 79%・PostgreSQL 77% など

### 3. ツール詳細ページ：「年別採用トレンド」
- 各年の登録サービスに対する採用率を横棒グラフで表示（統計ページとデザインを統一）

### その他
- 集計ロジックを `app/lib/related.ts` に追加
- `ToolSearch` 内のツール行UIを `ToolListItem` として共通コンポーネント化
- `getAllToolsData()` にキャッシュを追加し、ビルド時の繰り返しファイルI/Oを削減
- `ruby` / `rspec` / `rubocop` の表示名を正式表記（Ruby / RSpec / RuboCop）に修正（公式表記が小文字の factory_bot / minitest / foreman は変更なし）

## 動作確認

- [x] `npm run lint` パス
- [x] `npm run build` で全ページ（posts 105件・tools 198件）の静的生成成功
- [x] 生成HTMLで新セクションの内容（併用率・トレンド値・表記）を確認
- [x] Cypress E2E 7件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SA2eZRQbLQYJCQv1YJ4hPv