### PR TITLE
add_serviceスキルにツールアイコンの用意方法を追記

### DIFF
--- a/.claude/skills/add_service/SKILL.md
+++ b/.claude/skills/add_service/SKILL.md
@@ -91,7 +91,11 @@ node .claude/skills/add_service/scripts/check_post.mjs <id>
   ---
   ```
 
-- `WARN: アイコン ... がありません` → そのままでも動く（noimage表示）が、PR本文に「アイコン未登録」として明記する
+- `WARN: アイコン ... がありません` → 以下の優先順でアイコンを用意する:
+  1. ツール公式のロゴがあれば `public/images/tool/<tool_id>.png` として配置
+  2. 個別ロゴを持たないgemの場合は、RubyGemsアイコンを流用する:
+     `cp public/images/tool/solid_queue.png public/images/tool/<tool_id>.png`
+  3. どちらも難しければそのままでも動く（noimage表示）が、PR本文に「アイコン未登録」として明記する
 - exit 0 になるまで修正する
 
 ### 5. ビルド確認


### PR DESCRIPTION
## 概要

#219 の登録作業で確認したツールアイコンの運用を `/add_service` スキルに明文化しました。

新規ツール作成時のアイコンの優先順:

1. ツール公式のロゴがあれば `public/images/tool/<tool_id>.png` に配置
2. 個別ロゴを持たないgemは RubyGems アイコン（solid_queue.png と同じもの）を流用
3. どちらも難しければ noimage のまま、PR本文に明記

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SA2eZRQbLQYJCQv1YJ4hPv