### PR TITLE
存在しないIDの投稿・ツールページを500ではなく404にする

### DIFF
--- a/app/posts/[id]/page.tsx
+++ b/app/posts/[id]/page.tsx
@@ -16,6 +16,9 @@ export function generateStaticParams() {
   return getAllPostIds()
 }
 
+// 存在しないIDは404にする（未指定だとオンデマンド描画でENOENTの500になる）
+export const dynamicParams = false
+
 export async function generateMetadata({
   params,
 }: {

--- a/app/tools/[id]/page.tsx
+++ b/app/tools/[id]/page.tsx
@@ -13,6 +13,9 @@ export function generateStaticParams() {
   return allToolsData.map(({ toolID }) => ({ id: toolID }))
 }
 
+// 存在しないIDは404にする（未指定だとオンデマンド描画でENOENTの500になる）
+export const dynamicParams = false
+
 export async function generateMetadata({
   params,
 }: {


### PR DESCRIPTION
## 問題

存在しないIDのページ（例: 本番の https://fbc-stack.vercel.app/posts/zzz_not_exist ）にアクセスすると、404ではなく **500 (Application error)** になっていました。

`/posts/[id]` と `/tools/[id]` は `dynamicParams` 未指定（デフォルト true）のため、`generateStaticParams` に無いIDもオンデマンドで描画されようとし、`getPostData` / `getToolData` 内の `fs.readFileSync` が ENOENT を投げてRuntimeエラーになる、という流れです。未マージのサービスのURLを本番で開いた際に顕在化しましたが、以前から存在していたバグです。

## 修正

完全静的なサイトのため、両ページに `export const dynamicParams = false` を追加し、`generateStaticParams` に無いIDは即404を返すようにしました。

## 検証（ローカルの production build）

- [x] `/posts/zzz_not_exist` → 404（修正前: 500）
- [x] `/tools/zzz_not_exist` → 404（修正前: 500）
- [x] `/posts/bookrin` → 200 / `/tools/ruby_on_rails` → 200（既存ページに影響なし）
- [x] `npm run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SA2eZRQbLQYJCQv1YJ4hPv