### PR TITLE
技術スタックデータの表記ゆれ・不整合を修正 / CLAUDE.md刷新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 .DS_Store
 public/posts
 
+# local backup of untracked working data
+/backup
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+FBC-Stack is a Next.js application that showcases services built by Fjord Boot Camp (FBC) graduates and their technology stacks, with optional AI-generated podcast summaries for each service.
+
+## Tech Stack
+
+- Next.js 15 (App Router, SSG) + React 19 + TypeScript
+- Tailwind CSS v4 (via `@tailwindcss/postcss`)
+- Node.js >= 24 (see `.nvmrc`)
+
+## Common Development Commands
+
+```bash
+npm run dev              # Start dev server with HTTPS (copies posts/*.md to public/posts first)
+npm run build            # Production build (prebuild copies posts/*.md to public/posts)
+npm run start            # Start production server
+npm run lint             # Run ESLint
+npm run format           # Format with Prettier
+npm run e2e              # Start server + run Cypress interactively
+npm run e2e:headless     # Start server + run Cypress headlessly
+npx cypress run --spec "cypress/e2e/navigation.cy.ts"  # Run a single spec (server must be running)
+```
+
+## Architecture
+
+### Content Management
+
+All content is file-based; there is no database.
+
+- **Services**: `/posts/*.md` — frontmatter matches `PostData` (`types/postData.ts`): `date`, `title`, `author`, `website`, `blog`, `published`, `hasAudio`, `code` (GitHub repos with descriptions), and `stack` (categories with `name`/`version` tool entries). Markdown body is the service description.
+- **Tools**: `/tools/*.md` — frontmatter matches `ToolData` (`types/toolData.ts`): `toolName`, `url`, optional `alias`. Tool names in a post's `stack` are matched to tool pages case-insensitively via `toolName` or `alias` (see `createToolPathInfo` in `app/lib/posts.ts`).
+- **Podcast metadata**: `/podcast_data/*.json` keyed by post ID (`PodcastData` in `app/lib/podcast.ts`: audio URL, chapters, show notes, transcript URL). This directory is optional — all readers return `null`/`[]` when it is absent, so the site builds without it.
+
+### Build Process
+
+`predev`/`prebuild` copy `posts/*.md` into `public/posts/` (gitignored) so the markdown is also reachable client-side. No other generation steps run during build.
+
+### App Structure (App Router)
+
+- `app/page.tsx` — service list (top page)
+- `app/posts/[id]/page.tsx` — service detail (stack, related services, podcast player when data exists)
+- `app/tools/page.tsx`, `app/tools/[id]/page.tsx` — tool index and detail (services using the tool)
+- `app/stats/page.tsx` — tool usage statistics and yearly rankings
+- `app/about`, `app/privacy`, `app/terms`, `app/not-found.tsx`
+- `app/api/check-audio/route.ts` — HEAD-checks audio existence at `https://fbc-stack-storage.com/<postId>.m4a`
+
+### Data Loading (`app/lib/`)
+
+- `posts.ts` / `tools.ts` — parse markdown with `gray-matter`; results are module-level cached to avoid repeated file I/O during build
+- `podcast.ts` — reads `/podcast_data/*.json`, tolerant of missing files
+- `related.ts` — related services by Jaccard similarity of tool stacks
+- `stats.ts` — aggregates tool usage per year for the stats page
+- `image.ts`, `gtag.ts` — image helpers and Google Analytics
+
+### Podcast System
+
+Audio files are hosted externally at `https://fbc-stack-storage.com/` (not in this repo). A post shows the audio player only when `hasAudio` is true and matching podcast JSON exists. Generation tooling and past data live in `/backup` (gitignored, local only).
+
+## Environment Variables
+
+Defined in `.env.local` (template: `.env.local.template`, values via 1Password):
+
+- `NEXT_PUBLIC_BASE_URL`: Production URL (default: https://fbc-stack.vercel.app)
+- `NEXT_PUBLIC_GA_ID`: Google Analytics tracking ID
+
+## Testing
+
+- Cypress E2E tests in `/cypress/e2e/`
+- Tests expect the production server on `http://localhost:3000` (`npm run e2e` handles start + wait)
+
+## Claude Code Skills
+
+- `.claude/skills/add_service` — register a new service: analyzes a GitHub repo, generates `posts/<id>.md`, checks tool consistency, verifies the build, and opens a PR
+- `.claude/commands/` — `sound_link_remove`, `tech_stack_create`
+
+## Notes
+
+- `/backup` (gitignored) holds local-only working data: podcast JSON, whisper transcripts, one-off scripts, and images. Do not reference it from application code.

--- a/posts/anopost.md
+++ b/posts/anopost.md
@@ -10,7 +10,7 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail:
       - name: Ruby
         version: 
@@ -18,7 +18,7 @@ stack:
         version: 
       - name: JavaScript
         version: 
-  - name: backend
+  - name: バックエンド
     detail:
       - name: Ruby
         version: 
@@ -26,7 +26,7 @@ stack:
         version: 
       - name: RSpec
         version: 
-  - name: infra
+  - name: インフラ
     detail:
       - name: Heroku
         version:

--- a/posts/bookrin.md
+++ b/posts/bookrin.md
@@ -32,7 +32,7 @@ stack:
 
   - name: テスト
     detail:
-      - name: Minitest
+      - name: minitest
 
   - name: Linter/Formatter
     detail:

--- a/posts/bootcamp.md
+++ b/posts/bootcamp.md
@@ -38,7 +38,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.37.1
       - name: Slim-Lint
         version: 0.22.1

--- a/posts/braindriller.md
+++ b/posts/braindriller.md
@@ -10,7 +10,7 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail: 
       - name: Vue.js 
         version: 
@@ -18,13 +18,13 @@ stack:
         version:
       - name: JavaScript
         version:
-  - name: backend
+  - name: バックエンド
     detail: 
       - name: Ruby
         version:
       - name: Ruby on Rails
         version: 
-  - name: infra
+  - name: インフラ
     detail:
       - name: CircleCI
         version: 

--- a/posts/buzzcord.md
+++ b/posts/buzzcord.md
@@ -35,7 +35,7 @@ stack:
     detail:
       - name: Slim-Lint
         version: 0.22.1
-      - name: Rubocop
+      - name: RuboCop
         version: 1.30.1
 
   - name: テスト
@@ -50,7 +50,7 @@ stack:
 
   - name: ミドルウェア
     detail:
-      - name: puma
+      - name: Puma
         version: 5.6.4
 
   - name: データベース

--- a/posts/campus.md
+++ b/posts/campus.md
@@ -25,7 +25,7 @@ stack:
   - name: データベース
     detail:
       - name: PostgreSQL
-        version: 17.5
+        version: '17.5'
 
   - name: テスト
     detail:
@@ -41,7 +41,7 @@ stack:
   - name: 認証・機能
     detail:
       - name: Devise
-      - name: ActiveStorage
+      - name: Active Storage
       - name: Discard
       - name: Kaminari
 

--- a/posts/chatrank.md
+++ b/posts/chatrank.md
@@ -10,7 +10,7 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail: 
       - name: Ruby
         version: 3.0.2
@@ -18,13 +18,13 @@ stack:
         version: 
       - name: Slim
         version: 
-  - name: backend
+  - name: バックエンド
     detail:
       - name: Ruby
         version: 3.0.2
       - name: Ruby on Rails
         version: 6.1.4
-  - name: infra
+  - name: インフラ
     detail:
       - name: Heroku
         version: 

--- a/posts/chiikoma.md
+++ b/posts/chiikoma.md
@@ -30,7 +30,7 @@ stack:
 
   - name: Linter/Formatter
     detail: 
-      - name: Rubocop
+      - name: RuboCop
         version: 1.25.1
       - name: ESLint
         version: 7.23.0
@@ -44,7 +44,7 @@ stack:
 
   - name: 認証
     detail: 
-      - name: devise
+      - name: Devise
         version: 4.8.1
 
   - name: データベース

--- a/posts/circlecast.md
+++ b/posts/circlecast.md
@@ -22,9 +22,9 @@ stack:
   - name: バックエンド
     detail:
       - name: Ruby
-        version: 3.2
+        version: '3.2'
       - name: Ruby on Rails
-        version: 7.0
+        version: '7.0'
       - name: Devise
         version:
       - name: Active Storage
@@ -39,7 +39,7 @@ stack:
     detail:
       - name: ERB Lint
         version: 0.5.0
-      - name: Rubocop
+      - name: RuboCop
         version: 1.62.1
 
   - name: データベース

--- a/posts/credits_spot.md
+++ b/posts/credits_spot.md
@@ -51,7 +51,7 @@ stack:
 
   - name: CI/CD
     detail:
-      - name: Github Actions
+      - name: GitHub Actions
         version: 
 
 ---

--- a/posts/discord_botf.md
+++ b/posts/discord_botf.md
@@ -26,7 +26,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.16.0
       - name: Slim-Lint
         version: 0.21.1

--- a/posts/dowasure_note.md
+++ b/posts/dowasure_note.md
@@ -18,7 +18,7 @@ stack:
         version: 3.3.3
       - name: '@yaireo/tagify'
         version: '4.17.9'
-      - name: 'swiper'
+      - name: 'Swiper'
         version: '11.0.5'
 
   - name: バックエンド
@@ -43,7 +43,7 @@ stack:
         version: 8.53.0
       - name: Prettier
         version: 3.0.3
-      - name: Rubocop
+      - name: RuboCop
         version:
 
   - name: テスト

--- a/posts/duet_code.md
+++ b/posts/duet_code.md
@@ -36,14 +36,14 @@ stack:
         version: 8.25.0
       - name: Prettier
         version: 2.7.1
-      - name: rubocop
+      - name: RuboCop
         version: 1.36.0
 
   - name: インフラ
     detail:
       - name: Vercel
         version:
-      - name: Flyio
+      - name: Fly.io
         version:
 
   - name: テスト

--- a/posts/eigo_de_do_you_note.md
+++ b/posts/eigo_de_do_you_note.md
@@ -38,7 +38,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: '1.70.0'
       - name: ESLint
         version: '9.16.0'
@@ -52,7 +52,7 @@ stack:
 
   - name: デプロイ
     detail:
-      - name: fly.io
+      - name: Fly.io
         version: ''
 
   - name: インフラ

--- a/posts/employmate.md
+++ b/posts/employmate.md
@@ -47,7 +47,7 @@ stack:
         version: '8.38.0'
       - name: Prettier
         version: '2.8.7'
-      - name: Rubocop
+      - name: RuboCop
         version: ''
       - name: Stylelint
         version: '15.5.0'

--- a/posts/erasugi.md
+++ b/posts/erasugi.md
@@ -16,7 +16,7 @@ stack:
         version:
       - name: Tailwind CSS
         version:
-      - name: Konva.js
+      - name: konva.js
         version:
 
   - name: バックエンド
@@ -27,7 +27,7 @@ stack:
         version: 7.1.3.4
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version:
       - name: Prettier
         version:
@@ -35,7 +35,7 @@ stack:
         version:
   - name: テスト
     detail:
-      - name: Minitest
+      - name: minitest
         version:
   - name: データベース
     detail:

--- a/posts/euro_foot_checker.md
+++ b/posts/euro_foot_checker.md
@@ -28,7 +28,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.23.0
 
   - name: テスト
@@ -58,7 +58,7 @@ stack:
 
   - name: API連携
     detail:
-      - name: API-football
+      - name: API-Football
         version: 
 
 

--- a/posts/event_follow.md
+++ b/posts/event_follow.md
@@ -39,7 +39,7 @@ stack:
         version: 7.28.0
       - name: Prettier
         version: 2.2.1
-      - name: Rubocop
+      - name: RuboCop
         version: 1.11.0
 
   - name: テスト
@@ -54,7 +54,7 @@ stack:
   - name: データベース
     detail:
       - name: PostgreSQL
-        version: 5.4
+        version: '5.4'
 
   - name: 認証
     detail:

--- a/posts/f_form.md
+++ b/posts/f_form.md
@@ -10,7 +10,7 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail:
       - name: Ruby
         version: 2.7.1
@@ -18,17 +18,17 @@ stack:
         version: 
       - name: JavaScript
         version:
-  - name: backend
+  - name: バックエンド
     detail:
       - name: Ruby
         version: 2.7.2
       - name: Ruby on Rails
         version: 6.0.3.2
-  - name: datbase
+  - name: データベース
     detail:
       - name: PostgreSQL
-        version: 11
-  - name: infra
+        version: '11'
+  - name: インフラ
     detail:
       - name: Heroku
         version: 

--- a/posts/fbc_stack.md
+++ b/posts/fbc_stack.md
@@ -42,7 +42,7 @@ stack:
 
   - name: ストレージ
     detail:
-      - name: Github
+      - name: GitHub
         version: 
 
   - name: CI/CD

--- a/posts/fjord_calendar.md
+++ b/posts/fjord_calendar.md
@@ -34,7 +34,7 @@ stack:
     detail:
       - name: RuboCop
         version: 1.75.6
-      - name: erb_lint
+      - name: ERB Lint
         version: 0.9.0
       - name: ESLint
         version: 9.19.0

--- a/posts/fjord_choice.md
+++ b/posts/fjord_choice.md
@@ -28,11 +28,11 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: slim_lint
+      - name: Slim-Lint
         version: 0.22.1
       - name: ESLint
         version: "8.20"
-      - name: Rubocop
+      - name: RuboCop
         version: 1.36.0
 
   - name: テスト
@@ -43,7 +43,7 @@ stack:
   - name: データベース
     detail:
       - name: PostgreSQL
-        version: 5.4
+        version: '5.4'
 
   - name: 認証
     detail:
@@ -57,7 +57,7 @@ stack:
 
   - name: CI/CD
     detail:
-      - name: Github Actions
+      - name: GitHub Actions
         version: 
 
 ---

--- a/posts/fjord_minutes.md
+++ b/posts/fjord_minutes.md
@@ -41,29 +41,29 @@ stack:
     detail:
       - name: Devise
         version: ''
-      - name: omniauth
+      - name: OmniAuth
         version: ''
-      - name: omniauth-github
+      - name: OmniAuth GitHub
         version: ''
       - name: omniauth-rails_csrf_protection
         version: ''
 
   - name: Linter/Formatter
     detail:
-      - name: rubocop
+      - name: RuboCop
         version: ''
-      - name: erb_lint
+      - name: ERB Lint
         version: ''
-      - name: eslint
+      - name: ESLint
         version: ''
-      - name: prettier
+      - name: Prettier
         version: ''
 
   - name: テスト
     detail:
       - name: RSpec
         version: ''
-      - name: FactoryBot
+      - name: factory_bot
         version: ''
 
   - name: CI/CD
@@ -75,7 +75,7 @@ stack:
     detail:
       - name: Heroku
         version: ''
-      - name: redis
+      - name: Redis
         version: ''
 ---
 

--- a/posts/fjordbootcamp_contributors.md
+++ b/posts/fjordbootcamp_contributors.md
@@ -32,7 +32,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.36.0
       - name: Slim-Lint
         version: 0.22.1
@@ -45,7 +45,7 @@ stack:
   - name: データベース
     detail:
       - name: PostgreSQL
-        version: 5.4
+        version: '5.4'
 
   - name: インフラ
     detail:

--- a/posts/football_myteam.md
+++ b/posts/football_myteam.md
@@ -30,13 +30,13 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Slim-Lnt
+      - name: Slim-Lint
         version: 0.22.1
       - name: ESLint
         version: 7.32.0
       - name: Prettier
         version: 2.5.1
-      - name: Rubocop
+      - name: RuboCop
         version: 1.26.0
 
   - name: 認証

--- a/posts/giftreat.md
+++ b/posts/giftreat.md
@@ -35,7 +35,7 @@ stack:
 
   - name: テスト
     detail:
-      - name: Minitest
+      - name: minitest
 
   - name: CI/CD
     detail:

--- a/posts/gohan_summit.md
+++ b/posts/gohan_summit.md
@@ -28,7 +28,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version:
       - name: Prettier
         version:

--- a/posts/guitar_scale_sketch.md
+++ b/posts/guitar_scale_sketch.md
@@ -34,12 +34,12 @@ stack:
       - name: Ruby on Rails
         version: 7.0.4.3
       - name: Puma
-        version: 5.0
+        version: '5.0'
       - name: slim-rails
       - name: sentry-rails
-        version: 5.11
+        version: '5.11'
       - name: sentry-ruby
-        version: 5.11
+        version: '5.11'
 
   - name: ソーシャルログイン
     detail: 
@@ -57,7 +57,7 @@ stack:
         version: 8.46.0
       - name: Prettier
         version: 3.0.1
-      - name: Rubocop
+      - name: RuboCop
       - name: Slim-Lint
 
   - name: データベース

--- a/posts/habit_dungen.md
+++ b/posts/habit_dungen.md
@@ -10,7 +10,7 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail:
       - name: Ruby
         version: 2.6.5
@@ -20,17 +20,17 @@ stack:
         version: 
       - name: JavaScript
         version: 
-  - name: backend
+  - name: バックエンド
     detail:
       - name: Ruby
         version: 2.6.5
       - name: Ruby on Rails
         version: 6.0.2.2
-  - name: datbase
+  - name: データベース
     detail:
       - name: PostgreSQL
-        version: 11.5
-  - name: infra
+        version: '11.5'
+  - name: インフラ
     detail:
       - name: CircleCI
         version:
@@ -46,7 +46,7 @@ stack:
         version: 
       - name: Amazon S3
         version: 
-      - name: Amazon Cloudfront
+      - name: Amazon CloudFront
         version: 
       - name: Docker
         version: 

--- a/posts/honnohoshi.md
+++ b/posts/honnohoshi.md
@@ -10,7 +10,7 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail:
       - name: Ruby
         version: 
@@ -19,25 +19,25 @@ stack:
       - name: JavaScript
         version:
 
-  - name: backend
+  - name: バックエンド
     detail:
       - name: Ruby
         version: 
       - name: Ruby on Rails
         version: 
 
-  - name: database
+  - name: データベース
     detail:
       - name: PostgreSQL
         version: 
-  - name: api連携
+  - name: API連携
     detail:
       - name: 楽天API
         version: 
 
-  - name: infra
+  - name: インフラ
     detail:
-      - name: heroku
+      - name: Heroku
         version: 
 
 ---

--- a/posts/hoppo_reminder.md
+++ b/posts/hoppo_reminder.md
@@ -25,7 +25,7 @@ stack:
   - name: Linter/Formatter
     detail:
       - name: RuboCop
-      - name: Slim Lint
+      - name: Slim-Lint
       - name: ESLint
       - name: Prettier
 

--- a/posts/idearu.md
+++ b/posts/idearu.md
@@ -10,19 +10,19 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail: 
       - name: Ruby
         version: 3.0.2
       - name: Slim
         version: 
-  - name: backend
+  - name: バックエンド
     detail: 
       - name: Ruby
         version: 3.0.0
       - name: Ruby on Rails
         version: 6.1.4
-  - name: infra
+  - name: インフラ
     detail:
       - name: Heroku
         version: 

--- a/posts/kabu_calculator.md
+++ b/posts/kabu_calculator.md
@@ -33,12 +33,12 @@ stack:
   - name: データベースサーバ
     detail:
       - name: MySQL
-        version: 5.7
+        version: '5.7'
 
   - name: バッチシステム
     detail:
      - name: Python
-       version: 3.9
+       version: '3.9'
 
   - name: ビルドツール
     detail:
@@ -47,9 +47,9 @@ stack:
 
   - name: Linter/Formatter
     detail:
-     - name: Rubocop
+     - name: RuboCop
        version: 1.25.1
-     - name: Slim_Lint
+     - name: Slim-Lint
        version: 1.22.1
      - name: ESLint
        version: 8.8.0

--- a/posts/kanji_to_furigana.md
+++ b/posts/kanji_to_furigana.md
@@ -10,13 +10,13 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail: 
       - name: Chrome拡張
         version: 
       - name: JavaScript
         version: 
-  - name: backend
+  - name: バックエンド
     detail:
       - name: Ruby on Rails
         version: 7.0.3.1

--- a/posts/kanken_practice_note.md
+++ b/posts/kanken_practice_note.md
@@ -30,7 +30,7 @@ stack:
   - name: データベース
     detail:
       - name: SQLite
-        version: 3
+        version: '3'
       - name: Litestream
         version:
 
@@ -48,7 +48,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.47.0
       - name: ESLint
         version: 8.28.0
@@ -67,9 +67,9 @@ stack:
   - name: 開発環境
     detail:
       - name: Debian
-        version: 11.5
+        version: '11.5'
       - name: WSL
-        version: 2
+        version: '2'
 ---
 
 漢検練習帳は漢検準 1 級/1 級合格を目指す人向けの学習アプリです。 4 択クイズ形式で学習できます。

--- a/posts/kpi_tree.md
+++ b/posts/kpi_tree.md
@@ -15,14 +15,14 @@ stack:
       - name: Ruby
         version: 3.1.3
       - name: TypeScript
-        version: 4.9
+        version: '4.9'
 
   - name: フレームワーク
     detail:
       - name: Ruby on Rails
         version: 7.0.8
       - name: React
-        version: 18.2
+        version: '18.2'
       - name: Tailwind CSS
         version: 
       - name: daisyUI
@@ -36,7 +36,7 @@ stack:
   - name: データベース
     detail:
       - name: PostgreSQL
-        version: 15.3
+        version: '15.3'
 
   - name: ホスティング
     detail:

--- a/posts/kyudo_training_log.md
+++ b/posts/kyudo_training_log.md
@@ -28,7 +28,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: rubocop
+      - name: RuboCop
         version: 1.36.0
 
   - name: ビルドツール
@@ -38,7 +38,7 @@ stack:
 
   - name: インフラ
     detail:
-      - name: Flyio
+      - name: Fly.io
         version:
 
   - name: テスト
@@ -54,7 +54,7 @@ stack:
   - name: データベース
     detail:
       - name: PostgreSQL
-        version: 14.5
+        version: '14.5'
 
 ---
 

--- a/posts/letter.md
+++ b/posts/letter.md
@@ -17,7 +17,7 @@ stack:
   - name: バックエンド
     detail:
       - name: Ruby on Rails
-        version: 8
+        version: '8'
       - name: Solid Queue
       - name: Solid Cable
       - name: Solid Cache

--- a/posts/maaks.md
+++ b/posts/maaks.md
@@ -12,7 +12,7 @@ hasAudio: true
 stack:
   - name: フロントエンド
     detail:
-      - name: HotWire
+      - name: Hotwire
         version:
       - name: turbo-rails
         version: 1.4.0
@@ -34,13 +34,13 @@ stack:
 
   - name: 認証
     detail:
-      - name: devise
-        version: 4.9
+      - name: Devise
+        version: '4.9'
       - name: omniauth-google-oauth2
 
-  - name: リンター/フォーマッター
+  - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.53.1
       - name: ESLint
         version: 8.33.0
@@ -69,7 +69,7 @@ stack:
 
   - name: 外部サービス
     detail:
-      - name: MapBox GL JS
+      - name: Mapbox GL JS
 ---
 
 MAAKS はサイクリング中の事故を減らすための道路上の自転車事故やトラブルを共有するサービスです。ユーザーは地図上で他のユーザーが投稿した事故の情報やレポートを確認することができ、サイクリングルート設定時・走行時の危険予測が可能です。属コミュニティ化していた「危ないスポットの情報」をコミュニティの枠を超えて確認できるようになることで、より安全で楽しいライドに役立ちます。

--- a/posts/mapnica.md
+++ b/posts/mapnica.md
@@ -30,7 +30,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.23.0
       - name: ESLint
         version: 8.3.0

--- a/posts/maru_batsu_quiz.md
+++ b/posts/maru_batsu_quiz.md
@@ -18,7 +18,7 @@ stack:
         version: '^5.59.8'
       - name: Tailwind CSS
         version: '^3.3.2'
-      - name: DaisyUI
+      - name: daisyUI
         version: '^3.0.3'
 
   - name: バックエンド
@@ -53,7 +53,7 @@ stack:
       - name: Cypress
         version: '^12.13.0'
 
-  - name: リンター・フォーマッター
+  - name: Linter/Formatter
     detail:
       - name: ESLint
         version: '^8.42.0'
@@ -64,7 +64,7 @@ stack:
 
   - name: 外部サービス
     detail:
-      - name: SkyWay
+      - name: Skyway
         version: '^1.4.0'
       - name: Firebase Authentication
         version: '^9.22.1'

--- a/posts/medipet.md
+++ b/posts/medipet.md
@@ -10,7 +10,7 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail: 
       - name: Ruby
         version: 
@@ -21,12 +21,12 @@ stack:
       - name: JavaScript
         version:
  
-  - name: backend
+  - name: バックエンド
     detail: 
       - name: Ruby on Rails
         version: 
  
-  - name: infra
+  - name: インフラ
     detail:
       - name: Heroku
         version: 

--- a/posts/memo_recall.md
+++ b/posts/memo_recall.md
@@ -29,7 +29,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version:
       - name: ESLint
         version:

--- a/posts/mini_bootcamp.md
+++ b/posts/mini_bootcamp.md
@@ -34,7 +34,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.21.0
 
   - name: テスト

--- a/posts/my_film_todo.md
+++ b/posts/my_film_todo.md
@@ -10,7 +10,7 @@ website: https://my-film-todo.com/
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail: 
       - name: React
         version: 18.2.0
@@ -20,11 +20,11 @@ stack:
         version: 4.9.4
       - name: Chakra UI
         version: 
-  - name: infra
+  - name: インフラ
     detail:
       - name: Vercel
         version: 
-  - name: test
+  - name: テスト
     detail:
       - name: Jest
         version: 28.1.3

--- a/posts/myground.md
+++ b/posts/myground.md
@@ -32,7 +32,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.26.0
       - name: Prettier
         version: 2.6.0
@@ -50,7 +50,7 @@ stack:
   - name: データベース
     detail:
       - name: PostgreSQL
-        version: 14.1
+        version: '14.1'
 
   - name: CI/CD
     detail:

--- a/posts/nijikai_go.md
+++ b/posts/nijikai_go.md
@@ -22,7 +22,7 @@ stack:
       - name: Ruby
         version: 3.4.2
       - name: Ruby on Rails
-        version: 7.1
+        version: '7.1'
 
   - name: データベース
     detail:

--- a/posts/nurse_picks.md
+++ b/posts/nurse_picks.md
@@ -32,7 +32,7 @@ stack:
         version: 8.19.0
       - name: Prettier
         version: 2.7.1
-      - name: Rubocop
+      - name: RuboCop
         version: 1.14.0
       - name: Slim-Lint
         version: 0.22.1
@@ -45,7 +45,7 @@ stack:
   - name: データベース
     detail:
       - name: PostgreSQL
-        version: 5.4
+        version: '5.4'
 
   - name: 認証
     detail:
@@ -54,12 +54,12 @@ stack:
 
   - name: CI/CD
     detail:
-      - name: Github Actions
+      - name: GitHub Actions
         version:
 
   - name: インフラ
     detail:
-      - name: heroku
+      - name: Heroku
         version:
 ---
 

--- a/posts/order2post.md
+++ b/posts/order2post.md
@@ -18,7 +18,7 @@ stack:
         version: 5.2.2
       - name: Tailwind CSS
         version: 3.5.5
-      - name: vite
+      - name: Vite
         version: 4.5.0
 
   - name: バックエンド

--- a/posts/outdoor-heart-sutra.md
+++ b/posts/outdoor-heart-sutra.md
@@ -33,7 +33,7 @@ stack:
       - name: NextAuth.js
         version: 4.22.1
 
-  - name: リンター／フォーマッター
+  - name: Linter/Formatter
     detail:
       - name: RuboCop
         version: 1.55.1
@@ -74,7 +74,7 @@ stack:
     detail:
       - name: Google Maps API
         version: ""
-      - name: Google GeoCoding API
+      - name: Google Geocoding API
         version: ""
       - name: Amazon S3
         version: ""

--- a/posts/payreco.md
+++ b/posts/payreco.md
@@ -36,7 +36,7 @@ stack:
     detail:
       - name: Vercel
         version: 
-      - name: Flyio
+      - name: Fly.io
         version:
       - name: Docker
         version:
@@ -53,7 +53,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.35.0
       - name: ESLint
         version: 8.22.0

--- a/posts/php8_study_app.md
+++ b/posts/php8_study_app.md
@@ -14,7 +14,7 @@ stack:
     detail:
       - name: Hotwire
       - name: Tailwind CSS
-        version: 4.1
+        version: '4.1'
       - name: ViewComponent
 
   - name: バックエンド
@@ -32,7 +32,7 @@ stack:
   - name: テスト
     detail:
       - name: RSpec
-      - name: FactoryBot
+      - name: factory_bot
       - name: Capybara
       - name: SimpleCov
       - name: k6

--- a/posts/pixpick.md
+++ b/posts/pixpick.md
@@ -28,7 +28,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version:
       - name: Prettier
         version:

--- a/posts/pomoru.md
+++ b/posts/pomoru.md
@@ -24,7 +24,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.29.1
 
   - name: CI/CD

--- a/posts/prebill.md
+++ b/posts/prebill.md
@@ -10,19 +10,19 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail:
       - name: Ruby
         version: 
       - name: JavaScript
         version: 
-  - name: backend
+  - name: バックエンド
     detail:
       - name: Ruby
         version: 
       - name: Ruby on Rails
         version: 
-  - name: infra
+  - name: インフラ
     detail:
       - name: CircleCI
         version:

--- a/posts/pro_translate.md
+++ b/posts/pro_translate.md
@@ -20,7 +20,7 @@ stack:
         version: 
   - name: バックエンド
     detail:
-      - name: WebExtension Polyfill
+      - name: webextension-polyfill
         version: 
   - name: Linter/Formatter
     detail:

--- a/posts/quitcost.md
+++ b/posts/quitcost.md
@@ -37,7 +37,7 @@ stack:
  
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.24.0
       - name: Slim-Lint
         version: 0.22.1

--- a/posts/quotelist.md
+++ b/posts/quotelist.md
@@ -48,9 +48,9 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.48.0
-      - name: ERB-Lint
+      - name: ERB Lint
         version: 0.3.1
       - name: Slim-Lint
         version: 0.24.0
@@ -62,7 +62,7 @@ stack:
     detail:
       - name: RSpec
         version: 6.0.1
-      - name: Factory_bot
+      - name: factory_bot
         version: 6.2.1
   - name: データベース
     detail:

--- a/posts/radipos.md
+++ b/posts/radipos.md
@@ -10,7 +10,7 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail:
       - name: Ruby
         version: 
@@ -20,7 +20,7 @@ stack:
         version: 
       - name: JavaScript
         version: 
-  - name: backend
+  - name: バックエンド
     detail:
       - name: Ruby
         version: 
@@ -28,7 +28,7 @@ stack:
         version: 
       - name: RSpec
         version: 
-  - name: infra
+  - name: インフラ
     detail:
       - name: CircleCI
         version:

--- a/posts/re_read.md
+++ b/posts/re_read.md
@@ -36,9 +36,9 @@ stack:
         version: 8.7.0
       - name: Prettier
         version: 2.5.1
-      - name: Rubocop
+      - name: RuboCop
         version: 1.25.1
-      - name: Slim_Lint
+      - name: Slim-Lint
         version: 0.22.1
  
   - name: テスト

--- a/posts/recipe.md
+++ b/posts/recipe.md
@@ -10,19 +10,19 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail: 
       - name: Ruby
         version: 3.0.2
       - name: JavaScript
         version: 
-  - name: backend
+  - name: バックエンド
     detail:
       - name: Ruby on Rails
         version: 7.0.2.3
       - name: Ruby
         version: 3.0.2
-  - name: infra
+  - name: インフラ
     detail:
       - name: Heroku
         version: 

--- a/posts/resupple.md
+++ b/posts/resupple.md
@@ -10,7 +10,7 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail: 
       - name: Vue.js 
         version: 
@@ -20,13 +20,13 @@ stack:
         version:
       - name: JavaScript
         version:
-  - name: backend
+  - name: バックエンド
     detail: 
       - name: Ruby
         version:
       - name: Ruby on Rails
         version: 
-  - name: infra
+  - name: インフラ
     detail:
       - name: CircleCI
         version: 

--- a/posts/rewrite_logger.md
+++ b/posts/rewrite_logger.md
@@ -10,7 +10,7 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail:
       - name: Ruby
         version:
@@ -18,13 +18,13 @@ stack:
         version: 
       - name: JavaScript
         version:
-  - name: backend
+  - name: バックエンド
     detail:
       - name: Ruby
         version:
       - name: Ruby on Rails
         version: 
-  - name: infra
+  - name: インフラ
     detail:
       - name: CircleCI
         version: 

--- a/posts/roulette_talk.md
+++ b/posts/roulette_talk.md
@@ -36,7 +36,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version:
       - name: ESLint
         version: 8.48.0

--- a/posts/rubree.md
+++ b/posts/rubree.md
@@ -19,9 +19,9 @@ stack:
   - name: バックエンド
     detail:
       - name: Ruby
-        version: 3.3
+        version: '3.3'
       - name: Ruby on Rails
-        version: 8.0
+        version: '8.0'
       - name: Regexp::Parser
 
   - name: テスト
@@ -37,7 +37,7 @@ stack:
 
   - name: 開発
     detail:
-      - name: Foreman
+      - name: foreman
       - name: Lefthook
 
   - name: セキュリティ

--- a/posts/ruby_flash_card.md
+++ b/posts/ruby_flash_card.md
@@ -28,15 +28,15 @@ stack:
 
   - name: フロントエンドライブラリ
     detail:
-      - name: axios
+      - name: Axios
         version: 1.4.0
-      - name: react-toastify
+      - name: React-toastify
         version: 9.1.3
-      - name: 'react-textarea-code-editor'
+      - name: 'React Textarea Code Editor'
         version: 2.1.7
-      - name: react-hotkeys-hook
+      - name: React Hotkeys Hook
         version: 4.4.1
-      - name: prismjs
+      - name: Prism.js
         version: 1.29.0
 
   - name: バックエンド
@@ -50,21 +50,21 @@ stack:
     detail:
       - name: Devise
         version: 4.9.0
-      - name: omniauth
+      - name: OmniAuth
         version: 2.1.1
-      - name: omniauth-github
+      - name: OmniAuth GitHub
         version: 2.0.1
 
   - name: 検索
     detail:
-      - name: ransack
+      - name: Ransack
         version: 4.0.0
 
-  - name: リンター／フォーマッター
+  - name: Linter/Formatter
     detail:
       - name: RuboCop
         version: 1.54.2
-      - name: ERB-Lint
+      - name: ERB Lint
         version: 0.4.0
       - name: ESLint
         version: 8.45.0
@@ -75,7 +75,7 @@ stack:
     detail:
       - name: RSpec
         version: 6.0.3
-      - name: Factory_bot
+      - name: factory_bot
         version: 6.2.1
 
   - name: ランタイム

--- a/posts/ruumarker.md
+++ b/posts/ruumarker.md
@@ -15,7 +15,7 @@ stack:
       - name: Vue.js
         version: 3.2.31
       - name: Node.js
-        version: 16.14
+        version: '16.14'
       - name: daisyUI
         version: 2.14.2
       - name: Tailwind CSS
@@ -44,7 +44,7 @@ stack:
  
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.31.2
       - name: ESLint
         version: 7.32.0

--- a/posts/search_for_sugar.md
+++ b/posts/search_for_sugar.md
@@ -10,21 +10,21 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail: 
       - name: Ruby
         version: 2.7.0
       - name: Vue.js
-        version: 3.1
+        version: '3.1'
       - name: JavaScript
         version:
  
-  - name: backend
+  - name: バックエンド
     detail: 
       - name: Ruby on Rails
         version: 6.1.4.6
  
-  - name: infra
+  - name: インフラ
     detail:
       - name: Heroku
         version: 

--- a/posts/seppanda.md
+++ b/posts/seppanda.md
@@ -28,7 +28,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.24.1
       - name: ESLint
         version: 8.6.0

--- a/posts/serurepo.md
+++ b/posts/serurepo.md
@@ -46,7 +46,7 @@ stack:
     detail:
       - name: ESLint
         version: 7.32.0
-      - name: Rubocop
+      - name: RuboCop
         version: 1.30.1
       - name: Slim-Lint
         version: 0.22.1
@@ -83,7 +83,7 @@ stack:
         version: 
       - name: Amazon SES
         version: 
-      - name: Amazon Workmail
+      - name: Amazon WorkMail
         version: 
 
 ---

--- a/posts/shadone.md
+++ b/posts/shadone.md
@@ -34,7 +34,7 @@ stack:
         version: 8.15.0
       - name: Prettier
         version: 2.6.2
-      - name: Rubocop
+      - name: RuboCop
         version: 1.28.2
       - name: Slim-Lint
         version: 0.22.1

--- a/posts/sharecamp.md
+++ b/posts/sharecamp.md
@@ -10,7 +10,7 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail: 
       - name: Vue.js 
         version: 
@@ -20,7 +20,7 @@ stack:
         version:
       - name: JavaScript
         version:
-  - name: backend
+  - name: バックエンド
     detail: 
       - name: Ruby
         version:

--- a/posts/silver_calendar.md
+++ b/posts/silver_calendar.md
@@ -17,7 +17,7 @@ stack:
       - name: Vite
         version: 3.2.0
       - name: Bootstrap
-        version: 5
+        version: '5'
 
   - name: バックエンド
     detail: 
@@ -34,7 +34,7 @@ stack:
         version: "8.41.0"
       - name: Prettier
         version: "2.8.8"
-      - name: Rubocop
+      - name: RuboCop
         version: "1.39.0"
 
   - name: テスト
@@ -54,7 +54,7 @@ stack:
 
   - name: CI/CD
     detail:
-      - name: Github Actions
+      - name: GitHub Actions
         version: 
 
 ---

--- a/posts/skin_care_manager.md
+++ b/posts/skin_care_manager.md
@@ -22,7 +22,7 @@ stack:
         version: 4.1.0
       - name: Bootstrap
         version: 5.2.3
-      - name: Sassc
+      - name: SassC
         version: 2.4.0
 
   - name: バックエンド
@@ -34,13 +34,13 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: slim_lint
+      - name: Slim-Lint
         version: 0.24.0
       - name: ESLint
         version: "8.39.0"
       - name: Prettier
         version: "2.8.8"
-      - name: Rubocop
+      - name: RuboCop
         version: 1.50.2
 
   - name: テスト
@@ -60,7 +60,7 @@ stack:
 
   - name: CI/CD
     detail:
-      - name: Github Actions
+      - name: GitHub Actions
         version: 
 
 ---

--- a/posts/skincare_resume.md
+++ b/posts/skincare_resume.md
@@ -29,11 +29,11 @@ stack:
   - name: データベース
     detail:
       - name: PostgreSQL
-        version: 16.9
+        version: '16.9'
 
   - name: テスト
     detail:
-      - name: Minitest
+      - name: minitest
       - name: Capybara
 
   - name: Linter/Formatter

--- a/posts/slack_de_step.md
+++ b/posts/slack_de_step.md
@@ -10,14 +10,14 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail:
       - name: Ruby
         version: 
       - name: Slim
         version: 
       - name: JavaScript
-  - name: backend
+  - name: バックエンド
     detail:
       - name: Ruby
         version: 
@@ -25,7 +25,7 @@ stack:
         version: 
       - name: Slack
         version:
-  - name: infra
+  - name: インフラ
     detail:
       - name: Heroku
         version: 

--- a/posts/sleeple.md
+++ b/posts/sleeple.md
@@ -31,7 +31,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.24.1
 
   - name: テスト
@@ -42,7 +42,7 @@ stack:
   - name: データベース
     detail:
       - name: PostgreSQL
-        version: 14.3
+        version: '14.3'
 
   - name: 認証
     detail:
@@ -51,7 +51,7 @@ stack:
 
   - name: CI/CD
     detail:
-      - name: Github Actions
+      - name: GitHub Actions
         version:
 
   - name: インフラ

--- a/posts/smart_lottery.md
+++ b/posts/smart_lottery.md
@@ -37,7 +37,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.55.1
       - name: Slim-Lint
         version: 0.24.0

--- a/posts/sound_links.md
+++ b/posts/sound_links.md
@@ -17,14 +17,14 @@ stack:
       - name: TypeScript
         version: 4.2.3
       - name: Node.js
-        version: 14.3
+        version: '14.3'
 
   - name: バックエンド
     detail:
       - name: Ruby
         version: 3.0.3
       - name: Ruby on Rails (APIモード)
-        version: 6.1
+        version: '6.1'
 
   - name: Linter/Formatter
     detail:
@@ -32,7 +32,7 @@ stack:
         version: 6.8.0
       - name: Prettier
         version: 2.5.1
-      - name: Rubocop
+      - name: RuboCop
         version: 1.23.0
 
   - name: テスト
@@ -47,7 +47,7 @@ stack:
   - name: データベース
     detail:
       - name: PostgreSQL
-        version: 13.2
+        version: '13.2'
 
   - name: ミドルウェア
     detail:

--- a/posts/srive.md
+++ b/posts/srive.md
@@ -30,7 +30,7 @@ stack:
 
   - name: CI/CD
     detail:
-      - name: Github Actions
+      - name: GitHub Actions
         version: 
 
   - name: インフラ

--- a/posts/stampon.md
+++ b/posts/stampon.md
@@ -39,7 +39,7 @@ stack:
         version: 8.2.0
       - name: Prettier
         version: 2.4.1
-      - name: Rubocop
+      - name: RuboCop
         version: 1.22.3
 
   - name: テスト
@@ -57,7 +57,7 @@ stack:
   - name: データベース
     detail:
       - name: PostgreSQL
-        version: 13.4
+        version: '13.4'
 
   - name: インフラ
     detail:

--- a/posts/subs_mine.md
+++ b/posts/subs_mine.md
@@ -40,18 +40,18 @@ stack:
 
   - name: ビルドツール
     detail:
-      - name: webpack
+      - name: Webpack
         version: 5.78.0
 
   - name: Linter/Formatter
     detail:
-      - name: ESlint
+      - name: ESLint
         version: 8.37.0
       - name: Prettier
         version: 2.8.7
-      - name: Rubocop
+      - name: RuboCop
         version: 1.49.0
-      - name: slim_lint
+      - name: Slim-Lint
         version: 0.24.0
 
   - name: テスト

--- a/posts/subscmanage.md
+++ b/posts/subscmanage.md
@@ -25,7 +25,7 @@ stack:
 
   - name: テスト
     detail:
-      - name: Minitest
+      - name: minitest
 
   - name: Linter/Formatter
     detail:

--- a/posts/ten_no_koshitu.md
+++ b/posts/ten_no_koshitu.md
@@ -34,9 +34,9 @@ stack:
     detail:
       - name: ESLint
         version: 7.12.1
-      - name: Slim-lint
+      - name: Slim-Lint
         version: 0.20.2
-      - name: Rubocop
+      - name: RuboCop
         version: 1.3.0
 
   - name: テスト

--- a/posts/tenji_group_talk.md
+++ b/posts/tenji_group_talk.md
@@ -24,7 +24,7 @@ stack:
         version: 2.2.3
       - name: Propshaft
         version: 1.3.1
-      - name: Lucide Rails
+      - name: lucide-rails
         version: 0.7.3
 
   - name: バックエンド
@@ -52,13 +52,13 @@ stack:
     detail:
       - name: RSpec
       - name: Capybara
-      - name: FactoryBot
+      - name: factory_bot
       - name: SimpleCov
 
   - name: Linter/Formatter
     detail:
       - name: RuboCop
-      - name: Slim Lint
+      - name: Slim-Lint
       - name: Brakeman
       - name: ESLint
       - name: Prettier

--- a/posts/tenpai_speeder.md
+++ b/posts/tenpai_speeder.md
@@ -42,7 +42,7 @@ stack:
 
   - name: テスト
     detail:
-      - name: Minitest
+      - name: minitest
       - name: Capybara
 
   - name: Linter/Formatter

--- a/posts/tidal_force_plus.md
+++ b/posts/tidal_force_plus.md
@@ -25,7 +25,7 @@ stack:
 
   - name: テスト
     detail:
-      - name: Minitest
+      - name: minitest
 
   - name: Linter/Formatter
     detail:

--- a/posts/tsundoku.md
+++ b/posts/tsundoku.md
@@ -32,7 +32,7 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version:
       - name: ESLint
         version:
@@ -43,7 +43,7 @@ stack:
     detail:
       - name: RSpec
         version:
-      - name: FactoryBot
+      - name: factory_bot
         version:
       - name: SimpleCov
         version:

--- a/posts/tundaa.md
+++ b/posts/tundaa.md
@@ -10,7 +10,7 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail: 
       - name: Vue.js 
         version: 
@@ -20,19 +20,19 @@ stack:
         version:
       - name: JavaScript
         version:
-  - name: backend
+  - name: バックエンド
     detail: 
       - name: Ruby
         version: 3.0.0
       - name: Ruby on Rails
         version: 6.1.3
-  - name: database
+  - name: データベース
     detail: 
       - name: PostgreSQL
-        version: 11.11
+        version: '11.11'
       - name: Ruby on Rails
         version: 6.1.3
-  - name: infra
+  - name: インフラ
     detail:
       - name: Docker
         version: 

--- a/posts/twi_links.md
+++ b/posts/twi_links.md
@@ -10,7 +10,7 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail:
       - name: Ruby
         version: 3.1.0
@@ -18,13 +18,13 @@ stack:
         version: 
       - name: JavaScript
         version:
-  - name: backend
+  - name: バックエンド
     detail:
       - name: Ruby
         version: 3.1.0
       - name: Ruby on Rails
         version: 7.0.3.1
-  - name: database
+  - name: データベース
     detail:
       - name: PostgreSQL
         version: 

--- a/posts/twi_note.md
+++ b/posts/twi_note.md
@@ -10,7 +10,7 @@ website:
 published: false
 hasAudio: false
 stack:
-  - name: frontend
+  - name: フロントエンド
     detail:
       - name: Ruby
         version: 
@@ -20,7 +20,7 @@ stack:
         version: 
       - name: JavaScript
         version: 
-  - name: backend
+  - name: バックエンド
     detail:
       - name: Ruby
         version: 
@@ -28,7 +28,7 @@ stack:
         version: 
       - name: RSpec
         version: 
-      - name: Rubocop
+      - name: RuboCop
         version: 
 
   - name: API連携
@@ -36,7 +36,7 @@ stack:
       - name: Twitter API
         version:
 
-  - name: infra
+  - name: インフラ
     detail:
       - name: Heroku
         version:

--- a/posts/twicode.md
+++ b/posts/twicode.md
@@ -32,7 +32,7 @@ stack:
         version: 7.32.0
       - name: Prettier
         version: 2.4.0
-      - name: Rubocop
+      - name: RuboCop
         version: 1.22.1
   
   - name: ビルドツール

--- a/posts/typrogram.md
+++ b/posts/typrogram.md
@@ -17,9 +17,9 @@ stack:
       - name: React
         version: 19.0.0
       - name: TypeScript
-        version: 5
+        version: '5'
       - name: Tailwind CSS
-        version: 4
+        version: '4'
       - name: shadcn/ui
       - name: pnpm
 
@@ -33,12 +33,12 @@ stack:
   - name: データベース
     detail:
       - name: PostgreSQL
-        version: 17
+        version: '17'
 
   - name: 認証
     detail:
       - name: Auth.js
-        version: 5
+        version: '5'
       - name: JWT
 
   - name: テスト
@@ -53,7 +53,7 @@ stack:
       - name: RuboCop
         version: 1.81.7
       - name: ESLint
-        version: 9
+        version: '9'
       - name: Prettier
         version: 3.5.3
 

--- a/posts/utsumate.md
+++ b/posts/utsumate.md
@@ -32,7 +32,7 @@ stack:
         version: 8.23.0
       - name: Prettier
         version: 2.7.1
-      - name: Rubocop
+      - name: RuboCop
         version: 1.25.1
       - name: Slim-Lint
         version: 0.22.1
@@ -50,13 +50,13 @@ stack:
   - name: データベース
     detail:
       - name: PostgreSQL
-        version: 5.4
+        version: '5.4'
 
   - name: ミドルウェア
     detail:
       - name: nginx
         version:
-      - name: puma
+      - name: Puma
         version:
 
   - name: CI/CD

--- a/posts/vaccination_plan.md
+++ b/posts/vaccination_plan.md
@@ -40,9 +40,9 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.16.0
-      - name: Slim_Lint
+      - name: Slim-Lint
         version: 0.22.1
       - name: ESLint
         version: 7.32.0

--- a/posts/visible_scratch_skillz.md
+++ b/posts/visible_scratch_skillz.md
@@ -16,9 +16,9 @@ stack:
         version: 3.1.5
       - name: JavaScript
         version:
-      - name: Konva.js
+      - name: konva.js
         version: 8.1.1
-      - name: bulma
+      - name: Bulma
         version:
       - name: ERB
         version:
@@ -40,7 +40,7 @@ stack:
         version: 2.5.1
       - name: Stylelint
         version: 14.6.1
-      - name: Rubocop
+      - name: RuboCop
         version: 1.18.3
       - name: ERB Lint
         version: 0.1.1

--- a/posts/watermarkme.md
+++ b/posts/watermarkme.md
@@ -22,7 +22,7 @@ stack:
         version: 3.2.36
       - name: daisyUI
         version: 2.46.0
-      - name: tailwind CSS
+      - name: Tailwind CSS
         version: 3.2.4
 
   - name: バックエンド
@@ -38,9 +38,9 @@ stack:
         version: 8.26.0
       - name: Prettier
         version: 2.7.1
-      - name: Rubocop
+      - name: RuboCop
         version: 1.37.1
-      - name: slim-lint
+      - name: Slim-Lint
         version: 0.22.1
 
   - name: テスト

--- a/posts/zero_steps.md
+++ b/posts/zero_steps.md
@@ -28,16 +28,16 @@ stack:
 
   - name: Linter/Formatter
     detail:
-      - name: Rubocop
+      - name: RuboCop
         version: 1.62.1
-      - name: ERB-Lint
+      - name: ERB Lint
         version: 0.5.0
 
   - name: テスト
     detail:
       - name: RSpec
         version: 6.1.2
-      - name: Factory_bot
+      - name: factory_bot
         version: 6.4.6
 
   - name: データベース

--- a/tools/better_stack.md
+++ b/tools/better_stack.md
@@ -1,0 +1,5 @@
+---
+toolName: Better Stack
+alias:
+url: https://betterstack.com/
+---

--- a/tools/cloudflare.md
+++ b/tools/cloudflare.md
@@ -1,0 +1,5 @@
+---
+toolName: Cloudflare
+alias:
+url: https://www.cloudflare.com/
+---

--- a/tools/cloudflare_r2.md
+++ b/tools/cloudflare_r2.md
@@ -1,0 +1,5 @@
+---
+toolName: Cloudflare R2
+alias:
+url: https://developers.cloudflare.com/r2/
+---

--- a/tools/css.md
+++ b/tools/css.md
@@ -1,0 +1,5 @@
+---
+toolName: CSS
+alias:
+url: https://developer.mozilla.org/ja/docs/Web/CSS
+---

--- a/tools/git.md
+++ b/tools/git.md
@@ -1,0 +1,5 @@
+---
+toolName: Git
+alias:
+url: https://git-scm.com/
+---

--- a/tools/html.md
+++ b/tools/html.md
@@ -1,0 +1,5 @@
+---
+toolName: HTML
+alias:
+url: https://developer.mozilla.org/ja/docs/Web/HTML
+---

--- a/tools/jwt.md
+++ b/tools/jwt.md
@@ -1,0 +1,5 @@
+---
+toolName: JWT
+alias:
+url: https://jwt.io/
+---

--- a/tools/k6.md
+++ b/tools/k6.md
@@ -1,0 +1,5 @@
+---
+toolName: k6
+alias:
+url: https://k6.io/
+---

--- a/tools/lucide_rails.md
+++ b/tools/lucide_rails.md
@@ -1,0 +1,6 @@
+---
+toolName: lucide-rails
+alias:
+  - Lucide Rails
+url: https://github.com/heyvito/lucide-rails
+---

--- a/tools/pnpm.md
+++ b/tools/pnpm.md
@@ -1,0 +1,5 @@
+---
+toolName: pnpm
+alias:
+url: https://pnpm.io/
+---

--- a/tools/shadcn_ui.md
+++ b/tools/shadcn_ui.md
@@ -1,0 +1,5 @@
+---
+toolName: shadcn/ui
+alias:
+url: https://ui.shadcn.com/
+---

--- a/tools/slimlint.md
+++ b/tools/slimlint.md
@@ -6,6 +6,5 @@ alias:
   - slim_lint
   - Slim-lint
   - Slim_Lint
-  - Slim-Lnt
 url: https://github.com/sds/slim-lint
 ---

--- a/tools/torch_rb.md
+++ b/tools/torch_rb.md
@@ -1,0 +1,5 @@
+---
+toolName: torch-rb
+alias:
+url: https://github.com/ankane/torch.rb
+---


### PR DESCRIPTION
## 概要

全109サービスの技術スタックデータを機械監査し、表記ゆれ・不整合を修正しました。あわせて CLAUDE.md を現状の構成に合わせて刷新しています。

## 変更内容

### 技術スタックデータの修正(posts 98件・約250箇所)

- **ツール名の表記統一(約130箇所)**: `tools/*.md` の toolName / alias の正式表記に統一
  - 例: `Rubocop`(51件)・`rubocop`(3件) → `RuboCop`、`Github Actions` → `GitHub Actions`、`Flyio`・`fly.io` → `Fly.io`、`Minitest` → `minitest`、`Slim Lint` 等6変種 → `Slim-Lint`
  - タイポ修正: `Slim-Lnt` → `Slim-Lint`(回避用に登録されていたタイポ alias も削除)
- **カテゴリ名の統一(約60箇所)**: add_service スキルの規約表記に統一
  - `frontend` → `フロントエンド`、`backend` → `バックエンド`、`infra` → `インフラ`、タイポ `datbase` → `データベース` など
- **version の文字列化(44箇所)**: 数値としてパースされる version をクォート。YAML で `7.0` → `7` と末尾ゼロが消えていた表示を復元(circlecast の Rails `7.0`、rubree の `8.0` など)

### ツールページの追加(12件)

どのツールページにもリンクされていなかったスタック名に対応するページを追加:
HTML、CSS、Git、k6、Cloudflare、Cloudflare R2、Better Stack、lucide-rails、torch-rb、shadcn/ui、pnpm、JWT

### その他

- CLAUDE.md を実際の構成(App Router / Tailwind CSS v4)に合わせて刷新
- ローカル作業データの退避先 `/backup` を .gitignore に追加

## 検証

- 監査スクリプトの再実行で「ツールページ未リンク 0件・表記ゆれ 0件・数値型 version 0件」を確認
- `npm run build` 成功(サービス109件・ツール216件のページを静的生成)

## 補足(今回は未修正)

- PostgreSQL のバージョン `5.4` が5サービスに存在(PostgreSQL に 5.4 は存在せず、おそらく pg gem のバージョン)。作者記載を尊重して未変更
- 未参照のツールページ5件(aws、buetify、discord_bot、netlify、swagger)は URL 維持のため残置

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HXNbAPQaSVErAGod1mMns